### PR TITLE
fix: change how `ObjectValue`s are created

### DIFF
--- a/examples/playground/main.go
+++ b/examples/playground/main.go
@@ -25,10 +25,10 @@ func main() {
 				fgql.NewStringValue("str2"),
 				fgql.NewStringValue("str3"),
 			)),
-			fgql.NewArgument("object", fgql.NewObjectValue(map[string]*fgql.Value{
-				"field1": fgql.NewStringValue("str1"),
-				"field2": fgql.NewIntValue(123),
-			})),
+			fgql.NewArgument("object", fgql.NewObjectValue(
+				fgql.NewObjectValueField("field1", fgql.NewStringValue("str1")),
+				fgql.NewObjectValueField("field1", fgql.NewIntValue(123)),
+			)),
 			fgql.NewArgument("var", fgql.NewVariableValue("someVar")),
 		)).
 		Scalar("patrick").Parent().

--- a/fluentgraphql_test.go
+++ b/fluentgraphql_test.go
@@ -64,10 +64,10 @@ func TestSelections(t *testing.T) {
 		},
 		"SingleScalarWithObjectArgument": {
 			wantedQuery: `{ hello(arg1: { val1: "a", val2: "b"}) }`,
-			selection: NewQuery().Scalar("hello", WithArguments(NewArgument("arg1", NewObjectValue(map[string]*Value{
-				"val1": NewStringValue("a"),
-				"val2": NewStringValue("b"),
-			})))),
+			selection: NewQuery().Scalar("hello", WithArguments(NewArgument("arg1", NewObjectValue(
+				NewObjectValueField("val1", NewStringValue("a")),
+				NewObjectValueField("val2", NewStringValue("b")),
+			)))),
 		},
 		"SingleScalarWithVariableArgument": {
 			wantedQuery: `{ hello(arg1: $var1) }`,

--- a/values.go
+++ b/values.go
@@ -71,14 +71,27 @@ func NewListValue(values ...*Value) *Value {
 	}
 }
 
+type objectValueField struct {
+	fieldName string
+	value     *Value
+}
+
+// NewObjectValueField returns a field for an object value
+func NewObjectValueField(fieldName string, value *Value) *objectValueField {
+	return &objectValueField{
+		fieldName: fieldName,
+		value:     value,
+	}
+}
+
 // NewObjectValue returns an object value
-func NewObjectValue(values map[string]*Value) *Value {
+func NewObjectValue(values ...*objectValueField) *Value {
 	fields := make([]*ast.ObjectField, 0, len(values))
 
-	for n, v := range values {
+	for _, f := range values {
 		fields = append(fields, ast.NewObjectField(&ast.ObjectField{
-			Name:  ast.NewName(&ast.Name{Value: n}),
-			Value: v.astValue,
+			Name:  ast.NewName(&ast.Name{Value: f.fieldName}),
+			Value: f.value.astValue,
 		}))
 	}
 


### PR DESCRIPTION
previously using a Go `map`, where key order is not guaranteed, leading to flaky tests (where order matters as it impacts the produced AST, even if semantically there is no difference)